### PR TITLE
Allow poison 1.X

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -45,7 +45,7 @@ defmodule Exsyslog.Mixfile do
     [{:syslog, "~> 1.0.2"},
      {:ex_doc, "~> 0.7.3", only: :dev},
      {:earmark, "~> 0.1.17", only: :dev},
-     {:poison, "~> 1.4.0"}
+     {:poison, "~> 1.4"}
     ]
   end
 end


### PR DESCRIPTION
Poison is now at 1.5.0, this allows any poison 1.X, which is safe (in theory) semver wise.
