### PR TITLE
Add :syslog to included_applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,11 +24,11 @@ defp deps do
 end
 ```
 
-Add `:exsyslog` to your list of `included_applications`:
+Add `:exsyslog` and `:syslog` to your list of `included_applications`:
 
 ```elixir
 def application do
-  [included_applications: [:exsyslog]]
+  [included_applications: [:exsyslog, :syslog]]
 end
 ```
 


### PR DESCRIPTION
Without this, when running an exrm release on the exrm 1.0.4, when exsyslog attempts to start syslog, it will already be started and crash.

@bitwalker does this seem right? Is there something else wrong? This was not the case on 1.0.0-rc7, it was introduced somewhere after that.
