### PR TITLE
add support for Elixir 1.3

### DIFF
--- a/lib/ex_syslog.ex
+++ b/lib/ex_syslog.ex
@@ -59,6 +59,10 @@ defmodule ExSyslog do
     {:ok, state}
   end
 
+  def handle_event(:flush, state) do
+    {:ok, state}
+  end
+
 
   ##############################################################################
   #


### PR DESCRIPTION
Logger backends need to handle `:flush` messages now, I think nothing needs to be done as there is no real "flush" in erlang-syslog, so this just accepts the message and does nothing.
